### PR TITLE
Convert string to bytes if needed

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -42,6 +42,8 @@ def _use_cryptography_signer():
     )
 
     def _cloud_front_signer_from_pem(key_id, pem):
+        if isinstance(pem, str):
+            pem = pem.encode('ascii')
         key = load_pem_private_key(
             pem, password=None, backend=default_backend())
 
@@ -56,6 +58,8 @@ def _use_rsa_signer():
     import rsa
 
     def _cloud_front_signer_from_pem(key_id, pem):
+        if isinstance(pem, str):
+            pem = pem.encode('ascii')
         key = rsa.PrivateKey.load_pkcs1(pem)
         return CloudFrontSigner(key_id, lambda x: rsa.sign(x, key, 'SHA-1'))
 


### PR DESCRIPTION
When django-storages is used from an app which is configured by env variables
fed into dynaconf (or probably other siutations), it's not easy to directly
coerce a string representation of the signing key into a bytes-like object; it
comes in as a string.  This detects that situation and encodes the string.